### PR TITLE
HS-60558: Close client when buffer size is larger than maximum size

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.hectorclient</groupId>
     <artifactId>hector</artifactId>
-	<version>2.0-1</version>
+	<version>2.0-2</version>
   </parent>
 
   <artifactId>hector-core</artifactId>

--- a/core/src/main/java/me/prettyprint/cassandra/connection/HConnectionManager.java
+++ b/core/src/main/java/me/prettyprint/cassandra/connection/HConnectionManager.java
@@ -437,10 +437,7 @@ public class HConnectionManager {
     if ( pool == null ) {
       pool = suspendedHostPools.get(client.getCassandraHost());
     }
-    if ( pool != null ) {
-      if (client instanceof HThriftClient) {
-        ((HThriftClient) client).clearBuffers();
-      }
+    if ( pool != null && !shouldResetBuffer(client) ) {
       pool.releaseClient(client);
     } else {
       log.info("Client {} released to inactive or dead pool. Closing.", client);
@@ -509,4 +506,10 @@ public class HConnectionManager {
     cassandraHostRetryService.applyRetryDelay();
   }
 
+  private boolean shouldResetBuffer(HClient client) {
+    if (client instanceof HThriftClient) {
+      return ((HThriftClient) client).shouldResetBuffer();
+    }
+    return false;
+  }
 }

--- a/core/src/main/java/me/prettyprint/cassandra/connection/client/HThriftClient.java
+++ b/core/src/main/java/me/prettyprint/cassandra/connection/client/HThriftClient.java
@@ -17,6 +17,7 @@ import org.apache.cassandra.thrift.InvalidRequestException;
 import org.apache.commons.lang.StringUtils;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TBinaryProtocol;
+import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.transport.TFramedTransport;
 import org.apache.thrift.transport.TSSLTransportFactory;
 import org.apache.thrift.transport.TSocket;
@@ -322,12 +323,11 @@ public class HThriftClient implements HClient {
 
   /**
    * Avoids large read & write buffer of client. Be sure reset to less size of buffer.
-   * Please refer to cloudian jira issue: HS-54754
+   * Please refer to cloudian jira issue: HS-54754 & HS-60558
    */
-  public void clearBuffers() {
+  public boolean shouldResetBuffer() {
     byte[] buffer = transport.getBuffer();
-    if (buffer != null && buffer.length > MAX_BUFFER_SIZE) {
-      transport = maybeWrapWithTFramedTransport(socket);
-    }
+    return buffer != null && buffer.length > MAX_BUFFER_SIZE;
   }
+
 }

--- a/core/src/main/java/me/prettyprint/cassandra/connection/client/HThriftClient.java
+++ b/core/src/main/java/me/prettyprint/cassandra/connection/client/HThriftClient.java
@@ -17,7 +17,6 @@ import org.apache.cassandra.thrift.InvalidRequestException;
 import org.apache.commons.lang.StringUtils;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TBinaryProtocol;
-import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.transport.TFramedTransport;
 import org.apache.thrift.transport.TSSLTransportFactory;
 import org.apache.thrift.transport.TSocket;

--- a/object-mapper/pom.xml
+++ b/object-mapper/pom.xml
@@ -4,11 +4,10 @@
 	<parent>
 		<groupId>org.hectorclient</groupId>
 		<artifactId>hector</artifactId>
-		<version>2.0-1</version>
+		<version>2.0-2</version>
 	</parent>
 	<artifactId>hector-object-mapper</artifactId>
 	<name>hector-object-mapper</name>
-	<version>3.1-11</version>
 
 	<build>
 		<extensions>
@@ -50,7 +49,7 @@
 		<dependency>
 			<groupId>org.hectorclient</groupId>
 			<artifactId>hector-core</artifactId>
-			<version>2.0-1</version>
+			<version>${project.version}</version>
 			<exclusions>
 				<exclusion>
 					<groupId>log4j</groupId>
@@ -61,7 +60,7 @@
 		<dependency>
 			<groupId>org.hectorclient</groupId>
 			<artifactId>hector-test</artifactId>
-			<version>2.0-1</version>
+			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <groupId>org.hectorclient</groupId>
   <artifactId>hector</artifactId>
   <packaging>pom</packaging>
-  <version>2.0-1</version>
+  <version>2.0-2</version>
   <name>hector</name>
   <description>Cassandra Java Client Library</description>
   <url>http://github.com/hector-client/hector</url>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.hectorclient</groupId>
     <artifactId>hector</artifactId>
-    <version>2.0-1</version>
+    <version>2.0-2</version>
   </parent>
   <artifactId>hector-test</artifactId>
   <packaging>jar</packaging>


### PR DESCRIPTION
close client for thrift client if buffer size exceeds 1MB.